### PR TITLE
feat: expose scheduling catalog and technician endpoints

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { SchedulingModule } from './modules/scheduling/scheduling.module';
 
 @Module({
   imports: [
@@ -24,6 +25,7 @@ import { AppService } from './app.service';
         migrations: ['dist/migrations/*.js'],
       }),
     }),
+    SchedulingModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,18 @@
+import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.enableCors();
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      transform: true,
+      transformOptions: { enableImplicitConversion: true },
+      forbidNonWhitelisted: true,
+    }),
+  );
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();

--- a/src/modules/scheduling/catalog/catalog.module.ts
+++ b/src/modules/scheduling/catalog/catalog.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CatalogService } from './catalog.service';
+import { ServiceCategory } from './entities/service-category.entity';
+import { Service } from './entities/service.entity';
+import { ServiceCategoriesController } from './controllers/service-categories.controller';
+import { ServicesController } from './controllers/services.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ServiceCategory, Service])],
+  providers: [CatalogService],
+  controllers: [ServiceCategoriesController, ServicesController],
+  exports: [CatalogService],
+})
+export class CatalogModule {}

--- a/src/modules/scheduling/catalog/catalog.service.ts
+++ b/src/modules/scheduling/catalog/catalog.service.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { FindOptionsWhere, Repository } from 'typeorm';
+import { ServiceCategory } from './entities/service-category.entity';
+import { Service } from './entities/service.entity';
+
+interface ListCategoriesOptions {
+  includeInactive?: boolean;
+}
+
+interface ListServicesOptions {
+  includeInactive?: boolean;
+  categoryId?: string;
+}
+
+@Injectable()
+export class CatalogService {
+  constructor(
+    @InjectRepository(ServiceCategory) private readonly categoryRepo: Repository<ServiceCategory>,
+    @InjectRepository(Service) private readonly serviceRepo: Repository<Service>,
+  ) {}
+
+  listCategories(businessId: string, options: ListCategoriesOptions = {}) {
+    const where: FindOptionsWhere<ServiceCategory> = { businessId };
+    if (!options.includeInactive) {
+      where.isActive = true;
+    }
+
+    return this.categoryRepo.find({
+      where,
+      order: { position: 'ASC', name: 'ASC' },
+    });
+  }
+
+  listServices(businessId: string, options: ListServicesOptions = {}) {
+    const where: FindOptionsWhere<Service> = { businessId };
+
+    if (!options.includeInactive) {
+      where.isActive = true;
+    }
+
+    if (options.categoryId) {
+      where.categoryId = options.categoryId;
+    }
+
+    return this.serviceRepo.find({
+      where,
+      order: { name: 'ASC' },
+    });
+  }
+}

--- a/src/modules/scheduling/catalog/controllers/service-categories.controller.ts
+++ b/src/modules/scheduling/catalog/controllers/service-categories.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Get, Param, ParseUUIDPipe, Query } from '@nestjs/common';
+import { CatalogService } from '../catalog.service';
+import { ListServiceCategoriesQueryDto } from '../dto/list-service-categories-query.dto';
+import { ServiceCategoryDto, toServiceCategoryDto } from '../dto/service-category.dto';
+
+@Controller('businesses/:businessId/service-categories')
+export class ServiceCategoriesController {
+  constructor(private readonly catalogService: CatalogService) {}
+
+  @Get()
+  async list(
+    @Param('businessId', ParseUUIDPipe) businessId: string,
+    @Query() query: ListServiceCategoriesQueryDto,
+  ): Promise<ServiceCategoryDto[]> {
+    const categories = await this.catalogService.listCategories(businessId, {
+      includeInactive: query.includeInactive,
+    });
+
+    return categories.map(toServiceCategoryDto);
+  }
+}

--- a/src/modules/scheduling/catalog/controllers/services.controller.ts
+++ b/src/modules/scheduling/catalog/controllers/services.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Get, Param, ParseUUIDPipe, Query } from '@nestjs/common';
+import { CatalogService } from '../catalog.service';
+import { ListServicesQueryDto } from '../dto/list-services-query.dto';
+import { ServiceDto, toServiceDto } from '../dto/service.dto';
+
+@Controller('businesses/:businessId/services')
+export class ServicesController {
+  constructor(private readonly catalogService: CatalogService) {}
+
+  @Get()
+  async list(
+    @Param('businessId', ParseUUIDPipe) businessId: string,
+    @Query() query: ListServicesQueryDto,
+  ): Promise<ServiceDto[]> {
+    const services = await this.catalogService.listServices(businessId, {
+      includeInactive: query.includeInactive,
+      categoryId: query.categoryId,
+    });
+
+    return services.map(toServiceDto);
+  }
+}

--- a/src/modules/scheduling/catalog/dto/list-service-categories-query.dto.ts
+++ b/src/modules/scheduling/catalog/dto/list-service-categories-query.dto.ts
@@ -1,0 +1,9 @@
+import { Transform } from 'class-transformer';
+import { IsBoolean, IsOptional } from 'class-validator';
+
+export class ListServiceCategoriesQueryDto {
+  @IsOptional()
+  @Transform(({ value }) => value === true || value === 'true')
+  @IsBoolean()
+  includeInactive?: boolean;
+}

--- a/src/modules/scheduling/catalog/dto/list-services-query.dto.ts
+++ b/src/modules/scheduling/catalog/dto/list-services-query.dto.ts
@@ -1,0 +1,13 @@
+import { Transform } from 'class-transformer';
+import { IsBoolean, IsOptional, IsUUID } from 'class-validator';
+
+export class ListServicesQueryDto {
+  @IsOptional()
+  @IsUUID('4')
+  categoryId?: string;
+
+  @IsOptional()
+  @Transform(({ value }) => value === true || value === 'true')
+  @IsBoolean()
+  includeInactive?: boolean;
+}

--- a/src/modules/scheduling/catalog/dto/service-category.dto.ts
+++ b/src/modules/scheduling/catalog/dto/service-category.dto.ts
@@ -1,0 +1,17 @@
+import { ServiceCategory } from '../entities/service-category.entity';
+
+export interface ServiceCategoryDto {
+  id: string;
+  name: string;
+  description: string | null;
+  position: number;
+  isActive: boolean;
+}
+
+export const toServiceCategoryDto = (entity: ServiceCategory): ServiceCategoryDto => ({
+  id: entity.id,
+  name: entity.name,
+  description: entity.description ?? null,
+  position: entity.position,
+  isActive: entity.isActive,
+});

--- a/src/modules/scheduling/catalog/dto/service.dto.ts
+++ b/src/modules/scheduling/catalog/dto/service.dto.ts
@@ -1,0 +1,25 @@
+import { Service } from '../entities/service.entity';
+
+export interface ServiceDto {
+  id: string;
+  categoryId: string;
+  name: string;
+  description: string | null;
+  durationMinutes: number;
+  price: string;
+  preparationTimeMinutes: number;
+  bufferTimeMinutes: number;
+  isActive: boolean;
+}
+
+export const toServiceDto = (entity: Service): ServiceDto => ({
+  id: entity.id,
+  categoryId: entity.categoryId,
+  name: entity.name,
+  description: entity.description ?? null,
+  durationMinutes: entity.durationMinutes,
+  price: entity.price,
+  preparationTimeMinutes: entity.preparationTimeMinutes,
+  bufferTimeMinutes: entity.bufferTimeMinutes,
+  isActive: entity.isActive,
+});

--- a/src/modules/scheduling/scheduling.module.ts
+++ b/src/modules/scheduling/scheduling.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { CatalogModule } from './catalog/catalog.module';
+import { TechniciansModule } from './technicians/technicians.module';
+
+@Module({
+  imports: [CatalogModule, TechniciansModule],
+})
+export class SchedulingModule {}

--- a/src/modules/scheduling/technicians/controllers/technicians.controller.ts
+++ b/src/modules/scheduling/technicians/controllers/technicians.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Get, Param, ParseUUIDPipe, Query } from '@nestjs/common';
+import { TechniciansService } from '../services/technicians.service';
+import { ListTechniciansQueryDto } from '../dto/list-technicians-query.dto';
+import { TechnicianSummaryDto, toTechnicianSummaryDto } from '../dto/technician.dto';
+
+@Controller('businesses/:businessId/technicians')
+export class TechniciansController {
+  constructor(private readonly techniciansService: TechniciansService) {}
+
+  @Get()
+  async list(
+    @Param('businessId', ParseUUIDPipe) businessId: string,
+    @Query() query: ListTechniciansQueryDto,
+  ): Promise<TechnicianSummaryDto[]> {
+    const technicians = await this.techniciansService.listByBusiness(businessId, {
+      includeInactive: query.includeInactive,
+      serviceId: query.serviceId,
+    });
+
+    return technicians.map(item => toTechnicianSummaryDto(item.technician, item.serviceIds));
+  }
+}

--- a/src/modules/scheduling/technicians/dto/list-technicians-query.dto.ts
+++ b/src/modules/scheduling/technicians/dto/list-technicians-query.dto.ts
@@ -1,0 +1,13 @@
+import { Transform } from 'class-transformer';
+import { IsBoolean, IsOptional, IsUUID } from 'class-validator';
+
+export class ListTechniciansQueryDto {
+  @IsOptional()
+  @IsUUID('4')
+  serviceId?: string;
+
+  @IsOptional()
+  @Transform(({ value }) => value === true || value === 'true')
+  @IsBoolean()
+  includeInactive?: boolean;
+}

--- a/src/modules/scheduling/technicians/dto/technician.dto.ts
+++ b/src/modules/scheduling/technicians/dto/technician.dto.ts
@@ -1,0 +1,26 @@
+import { Technician } from '../entities/technician.entity';
+
+export interface TechnicianSummaryDto {
+  id: string;
+  displayName: string;
+  bio: string | null;
+  specialization: string | null;
+  ratingAverage: number | null;
+  userId: string | null;
+  isActive: boolean;
+  serviceIds: string[];
+}
+
+export const toTechnicianSummaryDto = (
+  technician: Technician,
+  serviceIds: string[],
+): TechnicianSummaryDto => ({
+  id: technician.id,
+  displayName: technician.displayName,
+  bio: technician.bio ?? null,
+  specialization: technician.specialization ?? null,
+  ratingAverage: technician.ratingAverage ? Number(technician.ratingAverage) : null,
+  userId: technician.userId ?? null,
+  isActive: technician.isActive,
+  serviceIds,
+});

--- a/src/modules/scheduling/technicians/services/technicians.service.ts
+++ b/src/modules/scheduling/technicians/services/technicians.service.ts
@@ -1,9 +1,14 @@
 // src/modules/scheduling/technicians/services/technicians.service.ts
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { Technician } from '../entities/technician.entity';
 import { TechnicianService as TechService } from '../entities/technician-service.entity';
+
+export interface TechnicianWithServices {
+  technician: Technician;
+  serviceIds: string[];
+}
 
 @Injectable()
 export class TechniciansService {
@@ -20,5 +25,43 @@ export class TechniciansService {
     await this.tsRepo.delete({ technicianId });
     const rows = serviceIds.map(serviceId => this.tsRepo.create({ technicianId, serviceId }));
     return this.tsRepo.save(rows); // PK (technician_id, service_id). :contentReference[oaicite:60]{index=60}
+  }
+
+  async listByBusiness(
+    businessId: string,
+    options: { includeInactive?: boolean; serviceId?: string } = {},
+  ): Promise<TechnicianWithServices[]> {
+    const technicians = await this.techRepo.find({
+      where: {
+        businessId,
+        ...(options.includeInactive ? {} : { isActive: true }),
+      },
+      order: { displayName: 'ASC', createdAt: 'ASC' },
+    });
+
+    if (!technicians.length) {
+      return [];
+    }
+
+    const assignments = await this.tsRepo.find({
+      where: { technicianId: In(technicians.map(tech => tech.id)) },
+    });
+
+    const assignmentsByTechnician = new Map<string, string[]>();
+    for (const assignment of assignments) {
+      if (!assignmentsByTechnician.has(assignment.technicianId)) {
+        assignmentsByTechnician.set(assignment.technicianId, []);
+      }
+      assignmentsByTechnician.get(assignment.technicianId)!.push(assignment.serviceId);
+    }
+
+    const filteredTechnicians = options.serviceId
+      ? technicians.filter(tech => (assignmentsByTechnician.get(tech.id) ?? []).includes(options.serviceId!))
+      : technicians;
+
+    return filteredTechnicians.map(technician => ({
+      technician,
+      serviceIds: assignmentsByTechnician.get(technician.id) ?? [],
+    }));
   }
 }

--- a/src/modules/scheduling/technicians/technicians.module.ts
+++ b/src/modules/scheduling/technicians/technicians.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TechniciansController } from './controllers/technicians.controller';
+import { Technician } from './entities/technician.entity';
+import { TechnicianService as TechnicianServiceEntity } from './entities/technician-service.entity';
+import { TechniciansService } from './services/technicians.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Technician, TechnicianServiceEntity])],
+  controllers: [TechniciansController],
+  providers: [TechniciansService],
+  exports: [TechniciansService],
+})
+export class TechniciansModule {}


### PR DESCRIPTION
## Summary
- enable global validation and CORS so HTTP DTOs can be transformed and sanitized
- register the scheduling module and provide catalog endpoints for service categories and services
- add technician listing APIs that include assigned service filters

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc11933d98832194712663cacdde68