### PR TITLE
Handle ESM data source resolution and address business location column type

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -19,6 +19,7 @@ import { SchedulingModule } from './modules/scheduling/scheduling.module';
         username: configService.get<string>('DB_USER'),
         password: configService.get<string>('DB_PASS'),
         database: configService.get<string>('DB_NAME'),
+        entities: [__dirname + '/**/*.entity{.ts,.js}'],
         autoLoadEntities: true,
         synchronize: false,
         migrationsRun: false,

--- a/src/core/business/business-location.entity.ts
+++ b/src/core/business/business-location.entity.ts
@@ -21,7 +21,7 @@ export class BusinessLocation extends SoftDeletableEntity {
   @IsString() @Length(1,200)
   addressLine1!: string;
 
-  @Column({ name: 'address_line2', length: 200, nullable: true })
+  @Column({ name: 'address_line2', type: 'varchar', length: 200, nullable: true })
   @IsOptional() @IsString()
   addressLine2?: string | null;
 

--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -1,7 +1,9 @@
 import 'dotenv/config';
+import { fileURLToPath } from 'node:url';
 import { DataSource } from 'typeorm';
 
-const isTsEnv = __filename.endsWith('.ts');
+const currentFile = fileURLToPath(import.meta.url);
+const isTsEnv = currentFile.endsWith('.ts');
 const rootDir = isTsEnv ? 'src' : 'dist';
 const fileExtension = isTsEnv ? 'ts' : 'js';
 


### PR DESCRIPTION
## Summary
- specify an explicit varchar column type for `BusinessLocation.addressLine2` so MySQL can register the entity metadata
- update the TypeORM data source to derive the file extension from `import.meta.url`, keeping CLI commands working under the NodeNext module setting

## Testing
- npm run lint *(fails: existing lint violations in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68dc336b4f2483218c071e412f99e62d